### PR TITLE
Update to support both runEra+runPeriod arguments

### DIFF
--- a/python/HHLepton.py
+++ b/python/HHLepton.py
@@ -9,11 +9,11 @@ from Base.Modules.baseModules import JetLepMetSyst, JetLepMetModule
 ROOT = import_root()
 
 class HHLeptonProducer(JetLepMetModule):
-    def __init__(self, isMC, year, runPeriod, *args, **kwargs):
+    def __init__(self, isMC, year, runEra, *args, **kwargs):
         super(HHLeptonProducer, self).__init__(*args, **kwargs)
         self.isMC = isMC
         self.year = year
-        self.runPeriod = runPeriod
+        self.runEra = runEra
         self.trigger_checker = TriggerChecker(year)
 
         if self.year == 2016:
@@ -24,7 +24,7 @@ class HHLeptonProducer(JetLepMetModule):
             self.trigger_checker.etau_triggers = ["HLT_Ele25_eta2p1_WPTight_Gsf"]
             self.trigger_checker.etau_crosstriggers = []
             if not self.isMC:
-                if self.runPeriod != "H":
+                if self.runEra != "H":
                     self.trigger_checker.tautau_triggers = [
                         "HLT_DoubleMediumIsoPFTau35_Trk1_eta2p1_Reg"]
                 else:
@@ -48,7 +48,7 @@ class HHLeptonProducer(JetLepMetModule):
                 "HLT_DoubleTightChargedIsoPFTau35_Trk1_TightID_eta2p1_Reg",
                 "HLT_DoubleMediumChargedIsoPFTau40_Trk1_TightID_eta2p1_Reg",
                 "HLT_DoubleTightChargedIsoPFTau40_Trk1_eta2p1_Reg"]
-            if self.runPeriod in ["D", "E", "F"] or self.isMC:
+            if self.runEra in ["D", "E", "F"] or self.isMC:
                 self.trigger_checker.vbf_triggers = [
                     "HLT_VBF_DoubleLooseChargedIsoPFTau20_Trk1_eta2p1_Reg"]
             else:
@@ -426,13 +426,13 @@ def HHLeptonVariable(**kwargs):
 
 
 class HHLeptonRDFProducer(JetLepMetSyst):
-    def __init__(self, isMC, year, runPeriod, df_filter, *args, **kwargs):
+    def __init__(self, isMC, year, runEra, pairType_filter, *args, **kwargs):
         super(HHLeptonRDFProducer, self).__init__(isMC=isMC, *args, **kwargs)
         self.isMC = isMC
         self.year = year
-        self.runPeriod = runPeriod
+        self.runEra = runEra
         self.isRun3 = kwargs.pop("isRun3", False)
-        self.df_filter = df_filter
+        self.pairType_filter = pairType_filter
         self.deeptau_version = kwargs.pop("deeptau_version", "2017v2p1")
         self.isV10 = kwargs.pop("isV10", False)
         vvvl_vsjet = kwargs.pop("vvvl_vsjet")
@@ -477,7 +477,7 @@ class HHLeptonRDFProducer(JetLepMetSyst):
                 ROOT.gInterpreter.Declare("""
                     using Vbool = const ROOT::RVec<Bool_t>&;
                     std::vector<trig_req> get_mutau_triggers(
-                            Vbool triggers, bool isMC, int run, int runPeriod) {
+                            Vbool triggers, bool isMC, int run, int runEra) {
                         std::vector<trig_req> trigger_reqs;
                         trigger_reqs.push_back(trig_req({triggers[4], 25, 2.3, 20, 2.3, {{2, 8}, {}}}));
                         trigger_reqs.push_back(trig_req({triggers[5], 28, 2.3, 20, 2.3, {{2, 8}, {}}}));
@@ -488,7 +488,7 @@ class HHLeptonRDFProducer(JetLepMetSyst):
                         return trigger_reqs;
                     }
                     std::vector<trig_req> get_etau_triggers(
-                            Vbool triggers, bool isMC, int run, int runPeriod) {
+                            Vbool triggers, bool isMC, int run, int runEra) {
                         std::vector<trig_req> trigger_reqs;
                         trigger_reqs.push_back(trig_req({triggers[2], 33, 2.3, 20, 2.3, {{2}, {}}}));
                         trigger_reqs.push_back(trig_req({triggers[3], 36, 2.3, 20, 2.3, {{2}, {}}}));
@@ -499,7 +499,7 @@ class HHLeptonRDFProducer(JetLepMetSyst):
                         return trigger_reqs;
                     }
                     std::vector<trig_req> get_tautau_triggers(
-                            Vbool triggers, bool isMC, bool isRun3, int run, int runPeriod) {
+                            Vbool triggers, bool isMC, bool isRun3, int run, int runEra) {
                         std::vector<trig_req> trigger_reqs;
                         trigger_reqs.push_back(trig_req({triggers[2], 40, 2.1, 40, 2.1, {{64, 4, 8}, {64, 4, 8}}}));
                         trigger_reqs.push_back(trig_req({triggers[3], 40, 2.1, 40, 2.1, {{64, 4, 8}, {64, 4, 8}}}));
@@ -516,7 +516,7 @@ class HHLeptonRDFProducer(JetLepMetSyst):
                         return trigger_reqs;
                     }
                     std::vector<trig_req> get_vbf_triggers(
-                            Vbool triggers, bool isMC, int run, int runPeriod) {
+                            Vbool triggers, bool isMC, int run, int runEra) {
                         std::vector<trig_req> trigger_reqs;
                         if (!isMC && run < 317509)
                             trigger_reqs.push_back(trig_req({triggers[1], 25, 2.1, 25, 2.1, {{64, 4, 8}, {64, 4, 8}}}));
@@ -529,7 +529,7 @@ class HHLeptonRDFProducer(JetLepMetSyst):
                 ROOT.gInterpreter.Declare("""
                     using Vbool = const ROOT::RVec<Bool_t>&;
                     std::vector<trig_req> get_mutau_triggers(
-                            Vbool triggers, bool isMC, int run, int runPeriod) {
+                            Vbool triggers, bool isMC, int run, int runEra) {
                         std::vector<trig_req> trigger_reqs;
                         trigger_reqs.push_back(trig_req({triggers[4], 25, 2.1, 20, 2.3, {{2, 8}, {}}}));
                         trigger_reqs.push_back(trig_req({triggers[5], 28, 2.1, 20, 2.3, {{2, 8}, {}}}));
@@ -540,7 +540,7 @@ class HHLeptonRDFProducer(JetLepMetSyst):
                         return trigger_reqs;
                     }
                     std::vector<trig_req> get_etau_triggers(
-                            Vbool triggers, bool isMC, int run, int runPeriod) {
+                            Vbool triggers, bool isMC, int run, int runEra) {
                         std::vector<trig_req> trigger_reqs;
                         trigger_reqs.push_back(trig_req({triggers[2], 33, 2.1, 20, 2.3, {{2}, {}}}));
                         trigger_reqs.push_back(trig_req({triggers[3], 36, 2.1, 20, 2.3, {{2}, {}}}));
@@ -551,7 +551,7 @@ class HHLeptonRDFProducer(JetLepMetSyst):
                         return trigger_reqs;
                     }
                     std::vector<trig_req> get_tautau_triggers(
-                            Vbool triggers, bool isMC, bool isRun3, int run, int runPeriod) {
+                            Vbool triggers, bool isMC, bool isRun3, int run, int runEra) {
                         std::vector<trig_req> trigger_reqs;
                         if (isRun3) {
                             trigger_reqs.push_back(trig_req({triggers[6], 40, 2.1, 40, 2.1, {{8, 32, 128}, {8, 32, 128}}}));
@@ -573,7 +573,7 @@ class HHLeptonRDFProducer(JetLepMetSyst):
                         return trigger_reqs;
                     }
                     std::vector<trig_req> get_vbf_triggers(
-                            Vbool triggers, bool isMC, int run, int runPeriod) {
+                            Vbool triggers, bool isMC, int run, int runEra) {
                         std::vector<trig_req> trigger_reqs;
                         if (!isMC && run < 317509)
                             trigger_reqs.push_back(trig_req({triggers[1], 25, 2.1, 25, 2.1, {{64, 4, 16}, {64, 4, 16}}}));
@@ -611,25 +611,25 @@ class HHLeptonRDFProducer(JetLepMetSyst):
             if branch not in all_branches:
                 self.vbf_triggers[ib] = "false"
 
-        runPeriods = ["dum", "A", "B", "C", "D", "E", "F", "G", "H"]
-        runPeriod = None
-        for irun, runPeriod in enumerate(runPeriods):
-            if self.runPeriod == runPeriod:
-                runPeriod = irun
+        runEras = ["dum", "A", "B", "C", "D", "E", "F", "G", "H"]
+        runEra = None
+        for irun, runEra in enumerate(runEras):
+            if self.runEra == runEra:
+                runEra = irun
                 break
-        assert runPeriod != None
+        assert runEra != None
 
         df = df.Define("mutau_triggers", "get_mutau_triggers({%s}, %s, run, %s)" % (
-            ", ".join(self.mutau_triggers), ("true" if self.isMC else "false"), runPeriod))
+            ", ".join(self.mutau_triggers), ("true" if self.isMC else "false"), runEra))
         df = df.Define("etau_triggers", "get_etau_triggers({%s}, %s, run, %s)" % (
-            ", ".join(self.etau_triggers), ("true" if self.isMC else "false"), runPeriod))
+            ", ".join(self.etau_triggers), ("true" if self.isMC else "false"), runEra))
         df = df.Define("tautau_triggers", "get_tautau_triggers({%s}, %s, %s, run, %s)" % (
             ", ".join(self.tautau_triggers), ("true" if self.isMC else "false"),
-            ("true" if self.isRun3 else "false"), runPeriod))
+            ("true" if self.isRun3 else "false"), runEra))
         df = df.Define("tautaujet_triggers", "get_tautaujet_triggers({%s}, %s)" % (
             ", ".join(self.tautaujet_triggers), ("true" if self.isRun3 else "false")))
         df = df.Define("vbf_triggers", "get_vbf_triggers({%s}, %s, run, %s)" % (
-            ", ".join(self.vbf_triggers), ("true" if self.isMC else "false"), runPeriod))
+            ", ".join(self.vbf_triggers), ("true" if self.isMC else "false"), runEra))
 
         Electron_mvaIso_WP80 = "Electron_mvaIso_WP80"
         if Electron_mvaIso_WP80 not in all_branches:
@@ -665,7 +665,7 @@ class HHLeptonRDFProducer(JetLepMetSyst):
             df = df.Define(branchName, "hh_lepton_results.%s" % var)
             branches.append(branchName)
 
-        if self.df_filter:
+        if self.pairType_filter:
             df = df.Filter("pairType >= 0")
 
         return df, branches
@@ -680,8 +680,8 @@ def HHLeptonRDF(**kwargs):
     Lepton systematics (used for pt and mass variables) can be modified using the parameters from 
     :ref:`BaseModules_JetLepMetSyst`.
 
-    :param runPeriod: run period in caps (data only)
-    :type runPeriod: str
+    :param runEra: run period in caps (data only)
+    :type runEra: str
 
     :param isV10: whether the input sample is from nanoaodV10 (default: ``False``)
     :type isV10: bool
@@ -718,17 +718,18 @@ def HHLeptonRDF(**kwargs):
                 isMC: self.dataset.process.isMC
                 isV10: self.dataset.has_tag("nanoV10")
                 year: self.config.year
+                runEra: self.dataset.runEra
                 runPeriod: self.dataset.runPeriod
                 vvvl_vsjet: self.config.deeptau.vsjet.VVVLoose
                 vl_vse: self.config.deeptau.vse.VLoose
                 vvl_vse: self.config.deeptau.vse.VVLoose
                 t_vsmu: self.config.deeptau.vsmu.Tight
                 vl_vsmu: self.config.deeptau.vsmu.VLoose
-                filter: True
+                pairType_filter: True
 
     """
-    df_filter = kwargs.pop("filter")
-    return lambda: HHLeptonRDFProducer(df_filter=df_filter, **kwargs)
+    pairType_filter = kwargs.pop("pairType_filter")
+    return lambda: HHLeptonRDFProducer(pairType_filter=pairType_filter, **kwargs)
 
 
 class HHLeptonVarRDFProducer(JetLepMetSyst):


### PR DESCRIPTION
Update to support both `runPeriod` and `ruEra` attributes of the `Dataset` class as reported in [this PR](https://gitlab.cern.ch/cms-phys-ciemat/analysis_tools/-/merge_requests/1)